### PR TITLE
Validation

### DIFF
--- a/dnas/grant_pools/zomes/coordinator/grants/src/evaluation.rs
+++ b/dnas/grant_pools/zomes/coordinator/grants/src/evaluation.rs
@@ -50,12 +50,3 @@ pub fn get_evaluations_for_application_by_agent(
     .filter(|l| l.author == input.agent)
     .collect())
 }
-pub fn get_score_for_evaluation(evaluation: Evaluation) -> u64 {
-    match evaluation.score {
-        Score::Single(score) => score,
-        Score::Weighted(vec) => {
-            let total: u64 = vec.iter().map(|score| score.value * score.weight).sum();
-            total
-        }
-    }
-}

--- a/dnas/grant_pools/zomes/integrity/grants/src/agent_to_evm_wallet.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/agent_to_evm_wallet.rs
@@ -1,12 +1,29 @@
+use alloy_primitives::Address;
 use hdi::prelude::*;
+
 pub fn validate_create_link_agent_to_evm_wallet(
     _action: CreateLink,
-    _base_address: AnyLinkableHash,
-    _target_address: AnyLinkableHash,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
     _tag: LinkTag,
 ) -> ExternResult<ValidateCallbackResult> {
-    // TODO: validate agentpubkey and evm_wallet
-    // try constructing Address from target bytes
+    let evm_address = String::from_utf8(target_address.into_inner()).map_err(|e| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Error converting target address to string: {:?}",
+            e
+        )))
+    })?;
+    if !AgentPubKey::try_from(base_address).is_ok() {
+        return Ok(ValidateCallbackResult::Invalid(
+            "Can only link wallet from an AgentPubKey".to_string(),
+        ));
+    }
+    if !Address::parse_checksummed(&evm_address, None).is_ok() {
+        return Ok(ValidateCallbackResult::Invalid(
+            "Can only link to valid evm address".to_string(),
+        ));
+    }
+
     Ok(ValidateCallbackResult::Valid)
 }
 pub fn validate_delete_link_agent_to_evm_wallet(

--- a/dnas/grant_pools/zomes/integrity/grants/src/agent_to_evm_wallet.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/agent_to_evm_wallet.rs
@@ -5,6 +5,8 @@ pub fn validate_create_link_agent_to_evm_wallet(
     _target_address: AnyLinkableHash,
     _tag: LinkTag,
 ) -> ExternResult<ValidateCallbackResult> {
+    // TODO: validate agentpubkey and evm_wallet
+    // try constructing Address from target bytes
     Ok(ValidateCallbackResult::Valid)
 }
 pub fn validate_delete_link_agent_to_evm_wallet(

--- a/dnas/grant_pools/zomes/integrity/grants/src/evaluation.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/evaluation.rs
@@ -1,5 +1,6 @@
 use crate::{EvaluationTemplate, ScoreTemplate};
 use hdi::prelude::*;
+use rust_decimal::Decimal;
 use std::iter::zip;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, SerializedBytes)]
 pub struct AttributeScore {
@@ -21,6 +22,21 @@ pub struct Evaluation {
     pub comments: String,
     pub score: Score,
 }
+
+pub fn get_score_for_evaluation(evaluation: Evaluation) -> u64 {
+    match evaluation.score {
+        Score::Single(score) => score,
+        Score::Weighted(vec) => {
+            let total: u64 = vec.iter().map(|score| score.value * score.weight).sum();
+            total
+        }
+    }
+}
+
+pub fn calc_absolute_score(raw_scores: Vec<u64>, num_evals: usize) -> Decimal {
+    Decimal::from(raw_scores.iter().sum::<u64>()) / Decimal::from(num_evals)
+}
+
 pub fn validate_create_evaluation(
     action: EntryCreationAction,
     evaluation: Evaluation,

--- a/dnas/grant_pools/zomes/integrity/grants/src/evaluation.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/evaluation.rs
@@ -1,4 +1,6 @@
+use crate::{EvaluationTemplate, ScoreTemplate};
 use hdi::prelude::*;
+use std::iter::zip;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, SerializedBytes)]
 pub struct AttributeScore {
     pub label: String,
@@ -23,8 +25,8 @@ pub fn validate_create_evaluation(
     action: EntryCreationAction,
     evaluation: Evaluation,
 ) -> ExternResult<ValidateCallbackResult> {
-    let record = must_get_valid_record(evaluation.application.clone())?;
-    let application: crate::Application = record
+    let app_record = must_get_valid_record(evaluation.application.clone())?;
+    let application: crate::Application = app_record
         .entry()
         .to_app_option()
         .map_err(|e| wasm_error!(e))?
@@ -32,8 +34,8 @@ pub fn validate_create_evaluation(
             "Dependant action must be accompanied by an entry"
         ))))?;
 
-    let record = must_get_valid_record(application.grant_pool)?;
-    let grant_pool: crate::GrantPool = record
+    let pool_record = must_get_valid_record(application.grant_pool)?;
+    let grant_pool: crate::GrantPool = pool_record
         .entry()
         .to_app_option()
         .map_err(|e| wasm_error!(e))?
@@ -45,6 +47,54 @@ pub fn validate_create_evaluation(
         return Ok(ValidateCallbackResult::Invalid(
             "Only the grant pool's evaluators can create evaluations".into(),
         ));
+    }
+
+    let eval_template_record = must_get_valid_record(grant_pool.evaluation_template)?;
+    let evaluation_template: EvaluationTemplate = eval_template_record
+        .entry()
+        .to_app_option()
+        .map_err(|e| wasm_error!(e))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(String::from(
+            "Dependant action must be accompanied by an entry"
+        ))))?;
+
+    match evaluation.score {
+        Score::Single(_) => {
+            if evaluation_template.score != ScoreTemplate::Single {
+                return Ok(ValidateCallbackResult::Invalid(
+                    "Evaluation score must match template".into(),
+                ));
+            }
+        }
+        Score::Weighted(mut scores) => match evaluation_template.score {
+            ScoreTemplate::Single => {
+                return Ok(ValidateCallbackResult::Invalid(
+                    "Evaluation score must match template".into(),
+                ));
+            }
+            ScoreTemplate::Weighted(mut scores_template) => {
+                if scores.len() != scores_template.len() {
+                    return Ok(ValidateCallbackResult::Invalid(
+                        "Evaluation score must match template".into(),
+                    ));
+                }
+                scores.sort_by_key(|s| s.label.clone());
+                scores_template.sort_by_key(|s| s.label.clone());
+                let iter = zip(scores, scores_template);
+                for item in iter {
+                    if item.0.label != item.1.label {
+                        return Ok(ValidateCallbackResult::Invalid(
+                            "Evaluation score must match template".into(),
+                        ));
+                    }
+                    if item.0.weight != item.1.weight {
+                        return Ok(ValidateCallbackResult::Invalid(
+                            "Evaluation score must match template".into(),
+                        ));
+                    }
+                }
+            }
+        },
     }
 
     Ok(ValidateCallbackResult::Valid)

--- a/dnas/grant_pools/zomes/integrity/grants/src/evaluation_template.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/evaluation_template.rs
@@ -2,13 +2,13 @@ use hdi::prelude::*;
 use serde_json::Value;
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, SerializedBytes)]
 pub struct NumberRange {
-    min: u32,
-    max: u32,
+    pub min: u32,
+    pub max: u32,
 }
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, SerializedBytes)]
 pub struct AttributeScoreTemplate {
-    label: String,
-    weight: u32,
+    pub label: String,
+    pub weight: u64,
 }
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, SerializedBytes)]
 #[serde(tag = "type", content = "content")]

--- a/dnas/grant_pools/zomes/integrity/grants/src/evaluator_to_applications.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/evaluator_to_applications.rs
@@ -1,7 +1,7 @@
 use hdi::prelude::*;
 pub fn validate_create_link_evaluator_to_applications(
     _action: CreateLink,
-    _base_address: AnyLinkableHash,
+    base_address: AnyLinkableHash,
     target_address: AnyLinkableHash,
     _tag: LinkTag,
 ) -> ExternResult<ValidateCallbackResult> {
@@ -19,6 +19,12 @@ pub fn validate_create_link_evaluator_to_applications(
         .ok_or(wasm_error!(WasmErrorInner::Guest(String::from(
             "Linked action must reference an entry"
         ))))?;
+    if !AgentPubKey::try_from(base_address).is_ok() {
+        return Ok(ValidateCallbackResult::Invalid(
+            "Can only evaluator from an AgentPubKey".to_string(),
+        ));
+    }
+
     Ok(ValidateCallbackResult::Valid)
 }
 pub fn validate_delete_link_evaluator_to_applications(
@@ -35,7 +41,7 @@ pub fn validate_delete_link_evaluator_to_applications(
 pub fn validate_create_link_application_to_evaluators(
     _action: CreateLink,
     base_address: AnyLinkableHash,
-    _target_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
     _tag: LinkTag,
 ) -> ExternResult<ValidateCallbackResult> {
     // Check the entry type for the given action hash
@@ -52,7 +58,12 @@ pub fn validate_create_link_application_to_evaluators(
         .ok_or(wasm_error!(WasmErrorInner::Guest(String::from(
             "Linked action must reference an entry"
         ))))?;
-    // TODO: add the appropriate validation rules
+    if !AgentPubKey::try_from(target_address).is_ok() {
+        return Ok(ValidateCallbackResult::Invalid(
+            "Can only link application to valid evaluator AgentPubKey".to_string(),
+        ));
+    }
+
     Ok(ValidateCallbackResult::Valid)
 }
 pub fn validate_delete_link_application_to_evaluators(

--- a/dnas/grant_pools/zomes/integrity/grants/src/grant_pool_outcome.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/grant_pool_outcome.rs
@@ -14,6 +14,7 @@ pub struct GrantPoolOutcome {
     pub grant_pool: ActionHash,
     pub deposits: BTreeMap<AgentPubKey, U256>,
     pub evaluations: BTreeMap<ActionHash, Vec<ActionHash>>,
+    // TODO: validate ranks match scores in evaluations
     pub ranked_list: Vec<AbsoluteScore>,
     pub coupon: Vec<u32>,
 }

--- a/dnas/grant_pools/zomes/integrity/grants/src/grant_pool_outcome.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/grant_pool_outcome.rs
@@ -1,8 +1,9 @@
-use crate::Evaluation;
+use crate::{calc_absolute_score, get_score_for_evaluation, Evaluation};
 use alloy_primitives::U256;
 use hdi::prelude::*;
 use rust_decimal::Decimal;
 use std::collections::BTreeMap;
+use std::iter::zip;
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct AbsoluteScore {
     pub application: ActionHash,
@@ -14,7 +15,6 @@ pub struct GrantPoolOutcome {
     pub grant_pool: ActionHash,
     pub deposits: BTreeMap<AgentPubKey, U256>,
     pub evaluations: BTreeMap<ActionHash, Vec<ActionHash>>,
-    // TODO: validate ranks match scores in evaluations
     pub ranked_list: Vec<AbsoluteScore>,
     pub coupon: Vec<u32>,
 }
@@ -35,21 +35,54 @@ pub fn validate_create_grant_pool_outcome(
             "Only grant pool author can create an outcome".to_string(),
         ));
     }
-    for (application, evaluations) in grant_pool_outcome.evaluations.clone() {
-        must_get_valid_record(application.clone())?;
-        for evaluation_action_hash in evaluations {
-            let record = must_get_valid_record(evaluation_action_hash.clone())?;
-            let _evaluation: Evaluation = record
+    let mut ranked_list = grant_pool_outcome.ranked_list.clone();
+    let mut absolute_scores = Vec::new();
+    for (app_action_hash, evaluation_action_hashes) in grant_pool_outcome.evaluations.clone() {
+        must_get_valid_record(app_action_hash.clone())?;
+        let mut raw_scores = Vec::new();
+        for eval_action_hash in evaluation_action_hashes.clone() {
+            let record = must_get_valid_record(eval_action_hash.clone())?;
+            let evaluation: Evaluation = record
                 .entry()
                 .to_app_option()
                 .map_err(|e| wasm_error!(e))?
                 .ok_or(wasm_error!(WasmErrorInner::Guest(String::from(
                     "Dependant action must be accompanied by an entry"
                 ))))?;
+
+            let score = get_score_for_evaluation(evaluation.clone());
+            raw_scores.push(score);
+        }
+        let absolute_score = AbsoluteScore {
+            application: app_action_hash.clone(),
+            score: calc_absolute_score(raw_scores, evaluation_action_hashes.clone().len()),
+        };
+        absolute_scores.push(absolute_score);
+    }
+    if grant_pool_outcome.evaluations.len() != ranked_list.len() {
+        return Ok(ValidateCallbackResult::Invalid(
+            "Ranked list must be same length as number of applications evaluated".into(),
+        ));
+    }
+    absolute_scores.sort_by_key(|s| s.application.clone());
+    ranked_list.sort_by_key(|s| s.application.clone());
+    let iter = zip(absolute_scores, ranked_list);
+    for item in iter {
+        if item.0.application != item.1.application {
+            return Ok(ValidateCallbackResult::Invalid(
+                "Ordered list of applications don't match".into(),
+            ));
+        }
+        if item.0.score != item.1.score {
+            return Ok(ValidateCallbackResult::Invalid(
+                "Absolute scores don't match".into(),
+            ));
         }
     }
+
     Ok(ValidateCallbackResult::Valid)
 }
+
 pub fn validate_update_grant_pool_outcome(
     _action: Update,
     _grant_pool_outcome: GrantPoolOutcome,

--- a/dnas/grant_pools/zomes/integrity/grants/src/lib.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/lib.rs
@@ -56,6 +56,7 @@ pub enum LinkTypes {
     EvaluatorToApplications,
     ApplicationToEvaluators,
 }
+
 #[hdk_extern]
 pub fn genesis_self_check(_data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
     Ok(ValidateCallbackResult::Valid)

--- a/dnas/grant_pools/zomes/integrity/grants/src/sponsor_to_grant_pools.rs
+++ b/dnas/grant_pools/zomes/integrity/grants/src/sponsor_to_grant_pools.rs
@@ -1,10 +1,16 @@
+use alloy_primitives::U256;
 use hdi::prelude::*;
 pub fn validate_create_link_sponsor_to_grant_pool(
     _action: CreateLink,
     _base_address: AnyLinkableHash,
     target_address: AnyLinkableHash,
-    _tag: LinkTag,
+    tag: LinkTag,
 ) -> ExternResult<ValidateCallbackResult> {
+    if U256::from_le_slice(&tag.into_inner()) == U256::from(0) {
+        return Ok(ValidateCallbackResult::Invalid(
+            "amount cannot be zero".to_string(),
+        ));
+    }
     let action_hash =
         target_address
             .into_action_hash()


### PR DESCRIPTION
pull out seperate fns for get_score_for_evaluation and calc_absolute_score

validation rules for:
-link to agent evm wallet, that agent is a valid AgentPubKey and evm wallet is a valid Address
-link evaluation and applications, only valid AgentPubKey for evaluator
-sponsor to grant pool linktag cannot be zero value for U256
-grant pool outcome, ranked list must match evaluation absolute scores